### PR TITLE
Fix MSVC build: use localtime_s and guard GCC pragma

### DIFF
--- a/src/FrogITApp/Frog.cpp
+++ b/src/FrogITApp/Frog.cpp
@@ -177,8 +177,13 @@ void Frog::handleClick()
 {
     auto now = std::chrono::system_clock::now();
     auto timeT = std::chrono::system_clock::to_time_t(now);
-    auto* localTime = std::localtime(&timeT);
-    int hour = localTime->tm_hour;
+    std::tm timeBuf{};
+#ifdef _WIN32
+    localtime_s(&timeBuf, &timeT);
+#else
+    localtime_r(&timeT, &timeBuf);
+#endif
+    int hour = timeBuf.tm_hour;
 
     const auto& phrases = getPhrasesForHour(hour);
     std::uniform_int_distribution<size_t> dist(0, phrases.size() - 1);

--- a/src/FrogITApp/Frog.hpp
+++ b/src/FrogITApp/Frog.hpp
@@ -29,11 +29,15 @@ class Frog
 
     sf::RenderWindow m_window;
     sf::Sprite m_sprite;
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
     const sf::Texture& m_texOpen;
     const sf::Texture& m_texClosed;
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
     float m_scale = 1.f;
 
     sf::Vector2f m_position{ 200.f, 200.f };


### PR DESCRIPTION
- Replace std::localtime with localtime_s (Win) / localtime_r (Unix) to fix MSVC error C4996
- Guard #pragma GCC diagnostic with #if defined(__GNUC__) to suppress MSVC warning C4068 (unknown pragma)